### PR TITLE
[13483] Add sync workflow to master

### DIFF
--- a/.github/workflows/rebase-ros-rmw_fastrtps.yml
+++ b/.github/workflows/rebase-ros-rmw_fastrtps.yml
@@ -1,0 +1,35 @@
+name: rebase-ros-rmw_fastrtps
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  # scheduled every midnight
+  workflow_dispatch:
+  #manual run of the workflow job
+
+jobs:
+  rebase-master:
+    name: Rebase HEAD with upstream ros2/rmw_fastrtps:master
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: run a standard checkout action, provided by github (REQUIRED)
+    - name: Checkout target repo
+      uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+
+      # Step 2: rebase action (REQUIRED)
+    - name: Rebase branch to upstream changes
+      id: rebase
+      run: |
+        git remote add ros https://github.com/ros2/rmw_fastrtps.git
+        git fetch ros master
+        git config --local user.email "ricardogonzalez@eprosima.com"
+        git config --local user.name "richiprosima"
+        git rebase ros/master
+        if [ "$(git status | grep diverged)" ]; then
+          git push -f
+        fi;
+      shell: bash


### PR DESCRIPTION
This workflow syncs remote repository master branch (ros2/rmw_fastrtps) with this fork master branch.

The workflow is programmed to run every midnight though it can also be launched manually.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>