### PR TITLE
Added multiple condition variable support

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -18,11 +18,13 @@
 #include <atomic>
 #include <condition_variable>
 #include <list>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -80,7 +82,7 @@ class ClientListener : public eprosima::fastdds::dds::DataReaderListener
 public:
   explicit ClientListener(CustomClientInfo * info)
   : info_(info), list_has_data_(false),
-    conditionMutex_(nullptr), conditionVariable_(nullptr) {}
+    conditionVariableList_() {}
 
 
   void
@@ -96,7 +98,7 @@ public:
     data.is_cdr_buffer = true;
     data.data = response.buffer_.get();
     data.impl = nullptr;    // not used when is_cdr_buffer is true
-    if (reader->take_next_sample(&data, &response.sample_info_) == ReturnCode_t::RETCODE_OK) {
+    while (reader->take_next_sample(&data, &response.sample_info_) == ReturnCode_t::RETCODE_OK) {
       if (response.sample_info_.valid_data) {
         response.sample_identity_ = response.sample_info_.related_sample_identity;
 
@@ -105,15 +107,20 @@ public:
         {
           std::lock_guard<std::mutex> lock(internalMutex_);
 
-          if (conditionMutex_ != nullptr) {
-            std::unique_lock<std::mutex> clock(*conditionMutex_);
+          if (!conditionVariableList_.empty()) {
+            std::vector<std::unique_lock<std::mutex>> vlock;
+            for (auto && m: mutexList_) {
+              vlock.emplace_back(*m);
+            }
             list.emplace_back(std::move(response));
             // the change to list_has_data_ needs to be mutually exclusive with
             // rmw_wait() which checks hasData() and decides if wait() needs to
             // be called
             list_has_data_.store(true);
-            clock.unlock();
-            conditionVariable_->notify_one();
+            vlock.clear();
+            for (auto && c : conditionVariableList_) {
+              c.first->notify_all();
+            }
           } else {
             list.emplace_back(std::move(response));
             list_has_data_.store(true);
@@ -128,8 +135,11 @@ public:
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
 
-    if (conditionMutex_ != nullptr) {
-      std::unique_lock<std::mutex> clock(*conditionMutex_);
+    if (!conditionVariableList_.empty()) {
+      std::vector<std::unique_lock<std::mutex>> vlock;
+      for (auto && m: mutexList_) {
+        vlock.emplace_back(*m);
+      }
       return popResponse(response);
     }
     return popResponse(response);
@@ -139,16 +149,27 @@ public:
   attachCondition(std::mutex * conditionMutex, std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = conditionMutex;
-    conditionVariable_ = conditionVariable;
+    conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
+    mutexList_.emplace_back(conditionMutex);
+    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
-  detachCondition()
+  detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = nullptr;
-    conditionVariable_ = nullptr;
+    std::map<std::condition_variable *, std::mutex *>::iterator it =
+      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
+      [=](std::pair<std::condition_variable *, std::mutex *> in)
+        {
+          return conditionVariable == in.first;
+        }
+      );
+    if (it != conditionVariableList_.end())
+    {
+      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
+      conditionVariableList_.erase(it);  
+    }
   }
 
   bool
@@ -190,8 +211,10 @@ private:
   std::mutex internalMutex_;
   std::list<CustomClientResponse> list RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::atomic_bool list_has_data_;
-  std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
-  std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+  std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
+    internalMutex_);
+  std::vector<std::mutex *> mutexList_;
+
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
@@ -70,7 +70,7 @@ public:
   : cv_list_(condition_variable_list)
   {
     if (!cv_list_.empty()) {
-      for (auto & c: cv_list_) {
+      for (auto && c: cv_list_) {
         c.second->lock();
       }
     }
@@ -79,7 +79,7 @@ public:
   ~ConditionalScopedLock()
   {
     if (!cv_list_.empty()) {
-      for (auto & c: cv_list_) {
+      for (auto && c: cv_list_) {
         c.second->unlock();
         c.first->notify_all();
       }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -116,26 +116,13 @@ public:
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
-    mutexList_.emplace_back(conditionMutex);
-    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
   detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    std::map<std::condition_variable *, std::mutex *>::iterator it =
-      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
-      [=](std::pair<std::condition_variable *, std::mutex *> in)
-        {
-          return conditionVariable == in.first;
-        }
-      );
-    if (it != conditionVariableList_.end())
-    {
-      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
-      conditionVariableList_.erase(it);  
-    }
+    conditionVariableList_.erase(conditionVariableList_.find(conditionVariable)); 
   }
 
 private:
@@ -154,7 +141,6 @@ private:
 
   std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
     internalMutex_);
-  std::vector<std::mutex *> mutexList_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_PUBLISHER_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -18,9 +18,10 @@
 #include <atomic>
 #include <condition_variable>
 #include <list>
+#include <map>
 #include <mutex>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -182,7 +183,7 @@ class ServiceListener : public eprosima::fastdds::dds::DataReaderListener
 public:
   explicit ServiceListener(CustomServiceInfo * info)
   : info_(info), list_has_data_(false),
-    conditionMutex_(nullptr), conditionVariable_(nullptr)
+    conditionVariableList_()
   {
   }
 
@@ -209,7 +210,7 @@ public:
     data.is_cdr_buffer = true;
     data.data = request.buffer_;
     data.impl = nullptr;    // not used when is_cdr_buffer is true
-    if (reader->take_next_sample(&data, &request.sample_info_) == ReturnCode_t::RETCODE_OK) {
+    while (reader->take_next_sample(&data, &request.sample_info_) == ReturnCode_t::RETCODE_OK) {
       if (request.sample_info_.valid_data) {
         request.sample_identity_ = request.sample_info_.sample_identity;
         // Use response subscriber guid (on related_sample_identity) when present.
@@ -226,15 +227,21 @@ public:
 
         std::lock_guard<std::mutex> lock(internalMutex_);
 
-        if (conditionMutex_ != nullptr) {
-          std::unique_lock<std::mutex> clock(*conditionMutex_);
+        if (!conditionVariableList_.empty()) {
+          std::vector<std::unique_lock<std::mutex>> vlock;
+          for (auto && m: mutexList_) {
+            vlock.emplace_back(*m);
+          }
           list.push_back(request);
           // the change to list_has_data_ needs to be mutually exclusive with
           // rmw_wait() which checks hasData() and decides if wait() needs to
           // be called
           list_has_data_.store(true);
-          clock.unlock();
-          conditionVariable_->notify_one();
+          //clock.unlock();
+          vlock.clear();
+          for (auto && c: conditionVariableList_) {
+            c.first->notify_all();
+          }
         } else {
           list.push_back(request);
           list_has_data_.store(true);
@@ -249,8 +256,11 @@ public:
     std::lock_guard<std::mutex> lock(internalMutex_);
     CustomServiceRequest request;
 
-    if (conditionMutex_ != nullptr) {
-      std::unique_lock<std::mutex> clock(*conditionMutex_);
+    if (!conditionVariableList_.empty()) {
+      std::vector<std::unique_lock<std::mutex>> vlock;
+      for (auto && m: mutexList_) {
+        vlock.emplace_back(*m);
+      }
       if (!list.empty()) {
         request = list.front();
         list.pop_front();
@@ -271,16 +281,27 @@ public:
   attachCondition(std::mutex * conditionMutex, std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = conditionMutex;
-    conditionVariable_ = conditionVariable;
+    conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
+    mutexList_.emplace_back(conditionMutex);
+    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
-  detachCondition()
+  detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = nullptr;
-    conditionVariable_ = nullptr;
+    std::map<std::condition_variable *, std::mutex *>::iterator it =
+      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
+      [=](std::pair<std::condition_variable *, std::mutex *> in)
+        {
+          return conditionVariable == in.first;
+        }
+      );
+    if (it != conditionVariableList_.end())
+    {
+      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
+      conditionVariableList_.erase(it);  
+    }
   }
 
   bool
@@ -294,8 +315,9 @@ private:
   std::mutex internalMutex_;
   std::list<CustomServiceRequest> list RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::atomic_bool list_has_data_;
-  std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
-  std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+  std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
+    internalMutex_);
+  std::vector<std::mutex *> mutexList_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_SERVICE_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -128,26 +128,13 @@ public:
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
-    mutexList_.emplace_back(conditionMutex);
-    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
   detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    std::map<std::condition_variable *, std::mutex *>::iterator it =
-      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
-      [=](std::pair<std::condition_variable *, std::mutex *> in)
-        {
-          return conditionVariable == in.first;
-        }
-      );
-    if (it != conditionVariableList_.end())
-    {
-      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
-      conditionVariableList_.erase(it);  
-    }
+    conditionVariableList_.erase(conditionVariableList_.find(conditionVariable)); 
   }
 
   bool
@@ -190,7 +177,6 @@ private:
 
   std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
     internalMutex_);
-  std::vector<std::mutex *> mutexList_;
 
   std::set<eprosima::fastrtps::rtps::GUID_t> publishers_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 };

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -32,7 +32,7 @@ PubListener::on_offered_deadline_missed(
 
   // the change to liveliness_lost_count_ needs to be mutually exclusive with
   // rmw_wait() which checks hasEvent() and decides if wait() needs to be called
-  ConditionalScopedLock clock(conditionMutex_, conditionVariable_);
+  ConditionalScopedLock clock(conditionVariableList_);
 
   // Assign absolute values
   offered_deadline_missed_status_.total_count = status.total_count;
@@ -50,7 +50,7 @@ void PubListener::on_liveliness_lost(
 
   // the change to liveliness_lost_count_ needs to be mutually exclusive with
   // rmw_wait() which checks hasEvent() and decides if wait() needs to be called
-  ConditionalScopedLock clock(conditionMutex_, conditionVariable_);
+  ConditionalScopedLock clock(conditionVariableList_);
 
   // Assign absolute values
   liveliness_lost_status_.total_count = status.total_count;

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -34,7 +34,7 @@ SubListener::on_requested_deadline_missed(
 
   // the change to liveliness_lost_count_ needs to be mutually exclusive with
   // rmw_wait() which checks hasEvent() and decides if wait() needs to be called
-  ConditionalScopedLock clock(conditionMutex_, conditionVariable_);
+  ConditionalScopedLock clock(conditionVariableList_);
 
   // Assign absolute values
   requested_deadline_missed_status_.total_count = status.total_count;
@@ -52,7 +52,7 @@ void SubListener::on_liveliness_changed(
 
   // the change to liveliness_lost_count_ needs to be mutually exclusive with
   // rmw_wait() which checks hasEvent() and decides if wait() needs to be called
-  ConditionalScopedLock clock(conditionMutex_, conditionVariable_);
+  ConditionalScopedLock clock(conditionVariableList_);
 
   // Assign absolute values
   liveliness_changed_status_.alive_count = status.alive_count;

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -195,7 +195,7 @@ __rmw_wait(
     for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
       void * data = subscriptions->subscribers[i];
       auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
-      custom_subscriber_info->listener_->detachCondition();
+      custom_subscriber_info->listener_->detachCondition(conditionVariable);
       if (!custom_subscriber_info->listener_->hasData()) {
         subscriptions->subscribers[i] = 0;
       }
@@ -206,7 +206,7 @@ __rmw_wait(
     for (size_t i = 0; i < clients->client_count; ++i) {
       void * data = clients->clients[i];
       auto custom_client_info = static_cast<CustomClientInfo *>(data);
-      custom_client_info->listener_->detachCondition();
+      custom_client_info->listener_->detachCondition(conditionVariable);
       if (!custom_client_info->listener_->hasData()) {
         clients->clients[i] = 0;
       }
@@ -217,7 +217,7 @@ __rmw_wait(
     for (size_t i = 0; i < services->service_count; ++i) {
       void * data = services->services[i];
       auto custom_service_info = static_cast<CustomServiceInfo *>(data);
-      custom_service_info->listener_->detachCondition();
+      custom_service_info->listener_->detachCondition(conditionVariable);
       if (!custom_service_info->listener_->hasData()) {
         services->services[i] = 0;
       }
@@ -228,7 +228,7 @@ __rmw_wait(
     for (size_t i = 0; i < events->event_count; ++i) {
       auto event = static_cast<rmw_event_t *>(events->events[i]);
       auto custom_event_info = static_cast<CustomEventInfo *>(event->data);
-      custom_event_info->getListener()->detachCondition();
+      custom_event_info->getListener()->detachCondition(conditionVariable);
       if (!custom_event_info->getListener()->hasEvent(event->event_type)) {
         events->events[i] = nullptr;
       }
@@ -239,7 +239,7 @@ __rmw_wait(
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
       void * data = guard_conditions->guard_conditions[i];
       auto guard_condition = static_cast<GuardCondition *>(data);
-      guard_condition->detachCondition();
+      guard_condition->detachCondition(conditionVariable);
       if (!guard_condition->getHasTriggered()) {
         guard_conditions->guard_conditions[i] = 0;
       }

--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -59,26 +59,13 @@ public:
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
-    mutexList_.emplace_back(conditionMutex);
-    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
   detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    std::map<std::condition_variable *, std::mutex *>::iterator it =
-      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
-      [=](std::pair<std::condition_variable *, std::mutex *> in)
-        {
-          return conditionVariable == in.first;
-        }
-      );
-    if (it != conditionVariableList_.end())
-    {
-      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
-      conditionVariableList_.erase(it);  
-    }
+    conditionVariableList_.erase(conditionVariableList_.find(conditionVariable)); 
   }
 
   bool
@@ -98,7 +85,6 @@ private:
   std::atomic_bool hasTriggered_;
   std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
     internalMutex_);
-  std::vector<std::mutex *> mutexList_;
 
 };
 

--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -15,12 +15,15 @@
 #ifndef TYPES__GUARD_CONDITION_HPP_
 #define TYPES__GUARD_CONDITION_HPP_
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cassert>
 #include <condition_variable>
 #include <mutex>
+#include <map>
 #include <utility>
+#include <vector>
 
 #include "rcpputils/thread_safety_annotations.hpp"
 
@@ -29,21 +32,23 @@ class GuardCondition
 public:
   GuardCondition()
   : hasTriggered_(false),
-    conditionMutex_(nullptr), conditionVariable_(nullptr) {}
+    conditionVariableList_() {}
 
   void
   trigger()
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
 
-    if (conditionMutex_ != nullptr) {
-      std::unique_lock<std::mutex> clock(*conditionMutex_);
-      // the change to hasTriggered_ needs to be mutually exclusive with
-      // rmw_wait() which checks hasTriggered() and decides if wait() needs to
-      // be called
-      hasTriggered_ = true;
-      clock.unlock();
-      conditionVariable_->notify_one();
+    if (!conditionVariableList_.empty()) {
+      for (auto && c: conditionVariableList_) {
+        std::unique_lock<std::mutex> clock(*c.second);
+        // the change to hasTriggered_ needs to be mutually exclusive with
+        // rmw_wait() which checks hasTriggered() and decides if wait() needs to
+        // be called
+        hasTriggered_ = true;
+        clock.unlock();
+        c.first->notify_all();
+      }
     } else {
       hasTriggered_ = true;
     }
@@ -53,16 +58,27 @@ public:
   attachCondition(std::mutex * conditionMutex, std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = conditionMutex;
-    conditionVariable_ = conditionVariable;
+    conditionVariableList_.insert(std::make_pair(conditionVariable, conditionMutex));
+    mutexList_.emplace_back(conditionMutex);
+    std::sort(mutexList_.begin(), mutexList_.end());
   }
 
   void
-  detachCondition()
+  detachCondition(std::condition_variable * conditionVariable)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
-    conditionMutex_ = nullptr;
-    conditionVariable_ = nullptr;
+    std::map<std::condition_variable *, std::mutex *>::iterator it =
+      std::find_if(conditionVariableList_.begin(), conditionVariableList_.end(),
+      [=](std::pair<std::condition_variable *, std::mutex *> in)
+        {
+          return conditionVariable == in.first;
+        }
+      );
+    if (it != conditionVariableList_.end())
+    {
+      mutexList_.erase(std::find(mutexList_.begin(), mutexList_.end(),it->second));
+      conditionVariableList_.erase(it);  
+    }
   }
 
   bool
@@ -80,8 +96,10 @@ public:
 private:
   std::mutex internalMutex_;
   std::atomic_bool hasTriggered_;
-  std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
-  std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+  std::map<std::condition_variable *, std::mutex *> conditionVariableList_ RCPPUTILS_TSA_GUARDED_BY(
+    internalMutex_);
+  std::vector<std::mutex *> mutexList_;
+
 };
 
 #endif  // TYPES__GUARD_CONDITION_HPP_


### PR DESCRIPTION
Previously only a single condition variable could be attached, causing the previous one to be overwritten. This PR fixes that behavior by allowing multiple conditions.