### PR TITLE
[20310] Feature: topic keys with non breaking ABI

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport.hpp
@@ -25,7 +25,7 @@ namespace rmw_fastrtps_cpp
 class MessageTypeSupport : public TypeSupport
 {
 public:
-  explicit MessageTypeSupport(const message_type_support_callbacks_t * members);
+  explicit MessageTypeSupport(const message_type_support_callbacks_t * members, uint8_t abi_version);
 };
 
 }  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -42,6 +42,9 @@ public:
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
+  bool getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+
   TypeSupport();
 
 protected:
@@ -49,6 +52,7 @@ protected:
 
 private:
   const message_type_support_callbacks_t * members_;
+  message_type_support_key_callbacks_t  key_callbacks_;
   bool has_data_;
 };
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -31,6 +31,8 @@
 namespace rmw_fastrtps_cpp
 {
 
+uint8_t get_type_support_abi_version(const char * identifier);
+
 class TypeSupport : public rmw_fastrtps_shared_cpp::TypeSupport
 {
 public:
@@ -50,9 +52,11 @@ public:
 protected:
   void set_members(const message_type_support_callbacks_t * members);
 
+  void set_members_v2(const message_type_support_callbacks_t * members);
+
 private:
   const message_type_support_callbacks_t * members_;
-  message_type_support_key_callbacks_t  key_callbacks_;
+  message_type_support_key_callbacks_t*  key_callbacks_;
   bool has_data_;
 };
 

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -266,6 +266,14 @@ rmw_fastrtps_cpp::create_publisher(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
+  }
+
   // Creates DataWriter with a mask enabling publication_matched calls for the listener
   info->data_writer_ = publisher->create_datawriter(
     info->topic_,

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -122,6 +122,8 @@ rmw_fastrtps_cpp::create_publisher(
     }
   }
 
+  uint8_t abi_version = get_type_support_abi_version(type_support->typesupport_identifier);
+
   std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
@@ -176,7 +178,7 @@ rmw_fastrtps_cpp::create_publisher(
   /////
   // Create the Type Support struct
   if (!fastdds_type) {
-    auto tsupport = new (std::nothrow) MessageTypeSupport_cpp(callbacks);
+    auto tsupport = new (std::nothrow) MessageTypeSupport_cpp(callbacks, abi_version);
     if (!tsupport) {
       RMW_SET_ERROR_MSG("create_publisher() failed to allocate MessageTypeSupport");
       return nullptr;

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -323,6 +323,14 @@ rmw_create_client(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->response_reader_ = subscriber->create_datareader(
     response_topic_desc,
@@ -379,6 +387,14 @@ rmw_create_client(
   {
     RMW_SET_ERROR_MSG("create_client() failed setting request DataWriter QoS");
     return nullptr;
+  }
+
+  /// Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter with a mask enabling publication_matched calls for the listener

--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -40,7 +40,9 @@ rmw_serialize(
   }
 
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(ts->data);
-  auto tss = MessageTypeSupport_cpp(callbacks);
+
+  uint8_t abi_version = rmw_fastrtps_cpp::get_type_support_abi_version(type_support->typesupport_identifier);
+  auto tss = MessageTypeSupport_cpp(callbacks, abi_version);
   auto data_length = tss.getEstimatedSerializedSize(ros_message, callbacks);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
@@ -78,7 +80,9 @@ rmw_deserialize(
   }
 
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(ts->data);
-  auto tss = MessageTypeSupport_cpp(callbacks);
+
+  uint8_t abi_version = rmw_fastrtps_cpp::get_type_support_abi_version(type_support->typesupport_identifier);
+  auto tss = MessageTypeSupport_cpp(callbacks, abi_version);
   eprosima::fastcdr::FastBuffer buffer(
     reinterpret_cast<char *>(serialized_message->buffer), serialized_message->buffer_length);
   eprosima::fastcdr::Cdr deser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -322,6 +322,14 @@ rmw_create_service(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->request_reader_ = subscriber->create_datareader(
     request_topic_desc,
@@ -382,6 +390,14 @@ rmw_create_service(
   {
     RMW_SET_ERROR_MSG("create_service() failed setting response DataWriter QoS");
     return nullptr;
+  }
+
+  /// Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter with a mask enabling publication_matched calls for the listener

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -392,6 +392,14 @@ __create_dynamic_subscription(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      info->datareader_qos_.history(),
+      info->datareader_qos_.resource_limits());
+  }
+
   info->datareader_qos_ = reader_qos;
 
   // create_datareader
@@ -659,6 +667,14 @@ __create_subscription(
   {
     RMW_SET_ERROR_MSG("create_subscription() failed setting data reader QoS");
     return nullptr;
+  }
+
+  /// Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
   }
 
   info->datareader_qos_ = reader_qos;

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -494,6 +494,8 @@ __create_subscription(
     }
   }
 
+  uint8_t abi_version = get_type_support_abi_version(type_support->typesupport_identifier);
+
   std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
@@ -549,7 +551,7 @@ __create_subscription(
   /////
   // Create the Type Support struct
   if (!fastdds_type) {
-    auto tsupport = new (std::nothrow) MessageTypeSupport_cpp(callbacks);
+    auto tsupport = new (std::nothrow) MessageTypeSupport_cpp(callbacks, abi_version);
     if (!tsupport) {
       RMW_SET_ERROR_MSG("create_subscription() failed to allocate MessageTypeSupport");
       return nullptr;

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -28,12 +28,14 @@ TypeSupport::TypeSupport()
   m_isGetKeyDefined = false;
   max_size_bound_ = false;
   is_plain_ = false;
+  key_is_unbounded_ = false;
+  key_max_serialized_size_ = 0;
 }
 
 void TypeSupport::set_members(const message_type_support_callbacks_t * members)
 {
   members_ = members;
-  m_isGetKeyDefined = members->get_key_type_support(&key_callbacks_);
+  m_isGetKeyDefined = members->get_key_type_support(&this->key_callbacks_);
 
 #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
   char bounds_info;
@@ -52,6 +54,23 @@ void TypeSupport::set_members(const message_type_support_callbacks_t * members)
     ++data_size;  // Dummy byte
   } else {
     has_data_ = true;
+  }
+
+  if (m_isGetKeyDefined)
+  {
+    std::cout << "Calculating max_serialized_key_size " << (&key_callbacks_.max_serialized_key_size) << std::endl;
+    this->key_max_serialized_size_ = this->key_callbacks_.max_serialized_key_size(0, this->key_is_unbounded_);
+    std::cout << "FInishing max_serialized_key_size" << std::endl;
+    if (!this->key_is_unbounded_)
+    {
+      this->key_buffer_.reserve(this->key_max_serialized_size_);
+    }
+    else
+    {
+      std::cout << "KEY is UNBOUNDED" << std::endl;
+    }
+
+    std::cout << "this->key_max_serialized_size_ " << this->key_max_serialized_size_ << std::endl;
   }
 
   // Total size is encapsulation size + data size
@@ -131,13 +150,68 @@ bool TypeSupport::deserializeROSmessage(
 }
 
 bool TypeSupport::getKeyHashFromROSmessage(
-    void *,
-    eprosima::fastrtps::rtps::InstanceHandle_t *,
-    bool,
-    const void *) const
+    void * ros_message,
+    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    bool force_md5,
+    const void * impl) const
 {
-  //!TODO
-  return false;
+  assert(ros_message);
+  (void)impl;
+
+  /*if (capacity < 16)
+  {
+    throw std::runtime_error("Not enough capacity to serialize key");
+  }*/
+
+  //! retrieve estimated serialized size in case key is unbounded
+  if (this->key_is_unbounded_)
+  {
+    std::cout << "Static Re-stimating serialize size. Before " << this->key_max_serialized_size_ << std::endl;
+    this->key_max_serialized_size_ = key_callbacks_.get_serialized_key_size(ros_message, 0);
+    std::cout << "Static Re-stimating serialize size. After " << this->key_max_serialized_size_ << std::endl;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+    std::cout << "Static New key buffer capacity " << this->key_buffer_.capacity() << std::endl;
+  }
+
+  eprosima::fastcdr::FastBuffer fast_buffer(
+    reinterpret_cast<char *>(this->key_buffer_.data()),
+    this->key_max_serialized_size_);
+
+  eprosima::fastcdr::Cdr ser(
+    fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+  key_callbacks_.cdr_serialize_key(ros_message, ser);
+
+    //! check for md5
+  if (force_md5 || this->key_max_serialized_size_ > 16)
+  {
+
+    this->md5_.init();
+
+#if FASTCDR_VERSION_MAJOR == 1
+    this->md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.getSerializedDataLength()));
+#else
+    this->md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.get_serialized_data_length()));
+#endif // FASTCDR_VERSION_MAJOR == 1
+
+    this->md5_.finalize();
+
+    for (uint8_t i = 0; i < 16; ++i)
+    {
+      ihandle->value[i] = md5_.digest[i];
+    }
+  }
+  else
+  {
+    for (uint8_t i = 0; i < 16; ++i)
+    {
+        ihandle->value[i] = this->key_buffer_[i];
+    }
+  }
+
+  std::cout << "\nFinishing static::getKeyHashFromROSmessage() "  << ihandle->value << std::endl;
+
+  return true;
 }
 
 MessageTypeSupport::MessageTypeSupport(const message_type_support_callbacks_t * members)

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -23,8 +23,22 @@
 namespace rmw_fastrtps_cpp
 {
 
+uint8_t get_type_support_abi_version(const char * identifier)
+{
+  uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+
+  if (strcmp(identifier, RMW_FASTRTPS_CPP_TYPESUPPORT_C_V2) == 0 ||
+      strcmp(identifier, RMW_FASTRTPS_CPP_TYPESUPPORT_CPP_V2) == 0)
+  {
+    abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V2;
+  }
+
+  return abi_version;
+}
+
 TypeSupport::TypeSupport()
 {
+  abi_version_ = AbiVersion::ABI_V1;
   m_isGetKeyDefined = false;
   max_size_bound_ = false;
   is_plain_ = false;
@@ -35,7 +49,6 @@ TypeSupport::TypeSupport()
 void TypeSupport::set_members(const message_type_support_callbacks_t * members)
 {
   members_ = members;
-  m_isGetKeyDefined = members->get_key_type_support(&this->key_callbacks_);
 
 #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
   char bounds_info;
@@ -56,27 +69,28 @@ void TypeSupport::set_members(const message_type_support_callbacks_t * members)
     has_data_ = true;
   }
 
-  if (m_isGetKeyDefined)
-  {
-    std::cout << "Calculating max_serialized_key_size " << (&key_callbacks_.max_serialized_key_size) << std::endl;
-    this->key_max_serialized_size_ = this->key_callbacks_.max_serialized_key_size(0, this->key_is_unbounded_);
-    std::cout << "FInishing max_serialized_key_size" << std::endl;
-    if (!this->key_is_unbounded_)
-    {
-      this->key_buffer_.reserve(this->key_max_serialized_size_);
-    }
-    else
-    {
-      std::cout << "KEY is UNBOUNDED" << std::endl;
-    }
-
-    std::cout << "this->key_max_serialized_size_ " << this->key_max_serialized_size_ << std::endl;
-  }
-
   // Total size is encapsulation size + data size
   m_typeSize = 4 + data_size;
   // Account for RTPS submessage alignment
   m_typeSize = (m_typeSize + 3) & ~3;
+}
+
+void TypeSupport::set_members_v2(const message_type_support_callbacks_t * members)
+{
+
+  set_members(members);
+
+  if (nullptr != members->key_callbacks)
+  {
+    this->key_callbacks_ = members->key_callbacks;
+    m_isGetKeyDefined = true;
+
+    this->key_max_serialized_size_ = this->key_callbacks_->max_serialized_key_size(0, this->key_is_unbounded_);
+    if (!this->key_is_unbounded_)
+    {
+      this->key_buffer_.reserve(this->key_max_serialized_size_);
+    }
+  }
 }
 
 size_t TypeSupport::getEstimatedSerializedSize(const void * ros_message, const void * impl) const
@@ -166,11 +180,8 @@ bool TypeSupport::getKeyHashFromROSmessage(
   //! retrieve estimated serialized size in case key is unbounded
   if (this->key_is_unbounded_)
   {
-    std::cout << "Static Re-stimating serialize size. Before " << this->key_max_serialized_size_ << std::endl;
-    this->key_max_serialized_size_ = key_callbacks_.get_serialized_key_size(ros_message, 0);
-    std::cout << "Static Re-stimating serialize size. After " << this->key_max_serialized_size_ << std::endl;
+    this->key_max_serialized_size_ = key_callbacks_->get_serialized_key_size(ros_message, 0);
     this->key_buffer_.reserve(this->key_max_serialized_size_);
-    std::cout << "Static New key buffer capacity " << this->key_buffer_.capacity() << std::endl;
   }
 
   eprosima::fastcdr::FastBuffer fast_buffer(
@@ -180,7 +191,7 @@ bool TypeSupport::getKeyHashFromROSmessage(
   eprosima::fastcdr::Cdr ser(
     fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
 
-  key_callbacks_.cdr_serialize_key(ros_message, ser);
+  key_callbacks_->cdr_serialize_key(ros_message, ser);
 
     //! check for md5
   if (force_md5 || this->key_max_serialized_size_ > 16)
@@ -209,19 +220,38 @@ bool TypeSupport::getKeyHashFromROSmessage(
     }
   }
 
-  std::cout << "\nFinishing static::getKeyHashFromROSmessage() "  << ihandle->value << std::endl;
-
   return true;
 }
 
-MessageTypeSupport::MessageTypeSupport(const message_type_support_callbacks_t * members)
+MessageTypeSupport::MessageTypeSupport(
+  const message_type_support_callbacks_t * members,
+  uint8_t abi_version)
 {
   assert(members);
+
+  abi_version_ = abi_version;
 
   std::string name = _create_type_name(members);
   this->setName(name.c_str());
 
-  set_members(members);
+  switch (abi_version)
+  {
+    case TypeSupport::AbiVersion::ABI_V1:
+    {
+      set_members(members);
+      break;
+    }
+    case TypeSupport::AbiVersion::ABI_V2:
+    {
+      set_members_v2(members);
+      break;
+    }
+    default:
+    {
+      set_members(members);
+      break;
+    }
+  }
 }
 
 ServiceTypeSupport::ServiceTypeSupport()

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -33,6 +33,7 @@ TypeSupport::TypeSupport()
 void TypeSupport::set_members(const message_type_support_callbacks_t * members)
 {
   members_ = members;
+  m_isGetKeyDefined = members->get_key_type_support(&key_callbacks_);
 
 #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
   char bounds_info;
@@ -127,6 +128,16 @@ bool TypeSupport::deserializeROSmessage(
   }
 
   return true;
+}
+
+bool TypeSupport::getKeyHashFromROSmessage(
+    void *,
+    eprosima::fastrtps::rtps::InstanceHandle_t *,
+    bool,
+    const void *) const
+{
+  //!TODO
+  return false;
 }
 
 MessageTypeSupport::MessageTypeSupport(const message_type_support_callbacks_t * members)

--- a/rmw_fastrtps_cpp/src/type_support_common.hpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.hpp
@@ -33,6 +33,8 @@
 #include "rosidl_typesupport_fastrtps_cpp/service_type_support.h"
 #define RMW_FASTRTPS_CPP_TYPESUPPORT_C rosidl_typesupport_fastrtps_c__identifier
 #define RMW_FASTRTPS_CPP_TYPESUPPORT_CPP rosidl_typesupport_fastrtps_cpp::typesupport_identifier
+#define RMW_FASTRTPS_CPP_TYPESUPPORT_C_V2 rosidl_typesupport_fastrtps_c__identifier_v2
+#define RMW_FASTRTPS_CPP_TYPESUPPORT_CPP_V2 rosidl_typesupport_fastrtps_cpp::typesupport_identifier_v2
 
 using MessageTypeSupport_cpp = rmw_fastrtps_cpp::MessageTypeSupport;
 using TypeSupport_cpp = rmw_fastrtps_cpp::TypeSupport;

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport.hpp
@@ -32,7 +32,7 @@ template<typename MembersType>
 class MessageTypeSupport : public TypeSupport<MembersType>
 {
 public:
-  MessageTypeSupport(const MembersType * members, const void * ros_type_support);
+  MessageTypeSupport(const MembersType * members, const void * ros_type_support, uint8_t abi_version);
 };
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport_impl.hpp
@@ -33,11 +33,12 @@ namespace rmw_fastrtps_dynamic_cpp
 
 template<typename MembersType>
 MessageTypeSupport<MembersType>::MessageTypeSupport(
-  const MembersType * members, const void * ros_type_support)
+  const MembersType * members, const void * ros_type_support, uint8_t abi_version)
 : TypeSupport<MembersType>(ros_type_support)
 {
   assert(members);
   this->members_ = members;
+  this->abi_version_ = abi_version;
 
   std::ostringstream ss;
   std::string message_namespace(this->members_->message_namespace_);

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/MessageTypeSupport_impl.hpp
@@ -56,10 +56,17 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0, this->key_max_serialized_size_));
   } else {
     this->m_typeSize++;
   }
+
+  if (this->key_max_serialized_size_ != 0)
+  {
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->m_typeSize = (this->m_typeSize + 3) & ~3;
 }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport.hpp
@@ -30,14 +30,14 @@ template<typename ServiceMembersType, typename MessageMembersType>
 class RequestTypeSupport : public TypeSupport<MessageMembersType>
 {
 public:
-  RequestTypeSupport(const ServiceMembersType * members, const void * ros_type_support);
+  RequestTypeSupport(const ServiceMembersType * members, const void * ros_type_support, uint8_t abi_version);
 };
 
 template<typename ServiceMembersType, typename MessageMembersType>
 class ResponseTypeSupport : public TypeSupport<MessageMembersType>
 {
 public:
-  ResponseTypeSupport(const ServiceMembersType * members, const void * ros_type_support);
+  ResponseTypeSupport(const ServiceMembersType * members, const void * ros_type_support, uint8_t abi_version);
 };
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport_impl.hpp
@@ -32,11 +32,12 @@ namespace rmw_fastrtps_dynamic_cpp
 
 template<typename ServiceMembersType, typename MessageMembersType>
 RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
-  const ServiceMembersType * members, const void * ros_type_support)
+  const ServiceMembersType * members, const void * ros_type_support, uint8_t abi_version)
 : TypeSupport<MessageMembersType>(ros_type_support)
 {
   assert(members);
   this->members_ = members->request_members_;
+  this->abi_version_ = abi_version;
 
   std::ostringstream ss;
   std::string service_namespace(members->service_namespace_);
@@ -72,11 +73,12 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
 
 template<typename ServiceMembersType, typename MessageMembersType>
 ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport(
-  const ServiceMembersType * members, const void * ros_type_support)
+  const ServiceMembersType * members, const void * ros_type_support, uint8_t abi_version)
 : TypeSupport<MessageMembersType>(ros_type_support)
 {
   assert(members);
   this->members_ = members->response_members_;
+  this->abi_version_ = abi_version;
 
   std::ostringstream ss;
   std::string service_namespace(members->service_namespace_);

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/ServiceTypeSupport_impl.hpp
@@ -55,10 +55,17 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0, this->key_max_serialized_size_));
   } else {
     this->m_typeSize++;
   }
+
+  if (this->key_max_serialized_size_ != 0)
+  {
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->m_typeSize = (this->m_typeSize + 3) & ~3;
 }
@@ -88,10 +95,17 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0, this->key_max_serialized_size_));
   } else {
     this->m_typeSize++;
   }
+
+  if (this->key_max_serialized_size_ != 0)
+  {
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->m_typeSize = (this->m_typeSize + 3) & ~3;
 }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
@@ -23,6 +23,7 @@
 
 #include "fastcdr/FastBuffer.h"
 #include "fastcdr/Cdr.h"
+#include "fastrtps/utils/md5.h"
 
 #include "rcutils/logging_macros.h"
 
@@ -138,6 +139,10 @@ public:
 
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
+
+  bool getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+
 };
 
 class BaseTypeSupport : public rmw_fastrtps_shared_cpp::TypeSupport
@@ -170,18 +175,27 @@ public:
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
+  bool getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+
 protected:
   explicit TypeSupport(const void * ros_type_support);
 
-  size_t calculateMaxSerializedSize(const MembersType * members, size_t current_alignment);
+  size_t calculateMaxSerializedSize(const MembersType * members, size_t current_alignment, size_t& max_key_size);
 
   const MembersType * members_;
+
+  bool key_is_unbounded_;
+  mutable size_t key_max_serialized_size_;
+  mutable MD5 md5_;
+  mutable std::vector<uint8_t> key_buffer_;
 
 private:
   size_t getEstimatedSerializedSize(
     const MembersType * members,
     const void * ros_message,
-    size_t current_alignment) const;
+    size_t current_alignment,
+    bool compute_key_members_only = false) const;
 
   bool serializeROSmessage(
     eprosima::fastcdr::Cdr & ser,
@@ -192,6 +206,18 @@ private:
     eprosima::fastcdr::Cdr & deser,
     const MembersType * members,
     void * ros_message) const;
+
+  bool serializeKeyROSmessage(
+    eprosima::fastcdr::Cdr & ser,
+    const MembersType * members,
+    void * ros_message,
+    bool check_if_member_is_key) const;
+
+  bool getKeyHashFromROSmessage(
+    const MembersType * members,
+    void * ros_message,
+    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    bool force_md5) const;
 };
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
@@ -23,7 +23,6 @@
 
 #include "fastcdr/FastBuffer.h"
 #include "fastcdr/Cdr.h"
-#include "fastrtps/utils/md5.h"
 
 #include "rcutils/logging_macros.h"
 
@@ -184,11 +183,6 @@ protected:
   size_t calculateMaxSerializedSize(const MembersType * members, size_t current_alignment, size_t& max_key_size);
 
   const MembersType * members_;
-
-  bool key_is_unbounded_;
-  mutable size_t key_max_serialized_size_;
-  mutable MD5 md5_;
-  mutable std::vector<uint8_t> key_buffer_;
 
 private:
   size_t getEstimatedSerializedSize(

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -311,7 +311,9 @@ bool TypeSupport<MembersType>::serializeKeyROSmessage(
   for (uint32_t i = 0; i < members->member_count_; ++i) {
     const auto member = members->members_ + i;
 
-    if (check_if_member_is_key && !member->is_key_)
+    if (check_if_member_is_key &&
+        this->abi_version_ != AbiVersion::ABI_V1 &&
+        !*(members->key_members_array_+i))
     {
       continue;
     }
@@ -638,7 +640,9 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
     const auto member = members->members_ + i;
     void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
 
-    if (compute_key_members_only && !member->is_key_)
+    if (compute_key_members_only &&
+        this->abi_version_ != AbiVersion::ABI_V1 &&
+        !*(members->key_members_array_+i))
     {
       continue;
     }
@@ -1000,7 +1004,8 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
     size_t array_size = 1;
     bool member_is_key = false;
 
-    if (member->is_key_)
+    if (this->abi_version_ != AbiVersion::ABI_V1 &&
+        *(members->key_members_array_+i))
     {
       member_is_key = true;
     }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -67,6 +67,8 @@ TypeSupport<MembersType>::TypeSupport(const void * ros_type_support)
   m_isGetKeyDefined = false;
   max_size_bound_ = false;
   is_plain_ = false;
+  key_max_serialized_size_ = 0;
+  key_is_unbounded_ = false;
 }
 
 // C++ specialization
@@ -299,6 +301,165 @@ bool TypeSupport<MembersType>::serializeROSmessage(
   return true;
 }
 
+template<typename MembersType>
+bool TypeSupport<MembersType>::serializeKeyROSmessage(
+  eprosima::fastcdr::Cdr & ser,
+  const MembersType * members,
+  void * ros_message,
+  bool check_if_member_is_key) const
+{
+  for (uint32_t i = 0; i < members->member_count_; ++i) {
+    const auto member = members->members_ + i;
+
+    if (check_if_member_is_key && !member->is_key_)
+    {
+      continue;
+    }
+
+    void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
+    switch (member->type_id_) {
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+        if (!member->is_array_) {
+          // don't cast to bool here because if the bool is
+          // uninitialized the random value can't be deserialized
+          ser << (*static_cast<uint8_t *>(field) ? true : false);
+        } else {
+          serialize_field<bool>(member, field, ser);
+        }
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+        serialize_field<uint8_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        serialize_field<char>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+        serialize_field<float>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+        serialize_field<double>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+        serialize_field<int16_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        serialize_field<uint16_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+        serialize_field<int32_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        serialize_field<uint32_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+        serialize_field<int64_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        serialize_field<uint64_t>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+            serialize_field<std::string>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING:
+        serialize_field<std::wstring>(member, field, ser);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        {
+          auto sub_members = static_cast<const MembersType *>(member->members_->data);
+          if (!member->is_array_) {
+            serializeKeyROSmessage(ser, sub_members, field, false);
+          } else {
+            size_t array_size = 0;
+
+            if (member->array_size_ && !member->is_upper_bound_) {
+              array_size = member->array_size_;
+            } else {
+              if (!member->size_function) {
+                RMW_SET_ERROR_MSG("unexpected error: size function is null");
+                return false;
+              }
+              array_size = member->size_function(field);
+
+              // Serialize length
+              ser << (uint32_t)array_size;
+            }
+
+            if (array_size != 0 && !member->get_function) {
+              RMW_SET_ERROR_MSG("unexpected error: get_function function is null");
+              return false;
+            }
+            for (size_t index = 0; index < array_size; ++index) {
+              serializeKeyROSmessage(ser, sub_members, member->get_function(field, index), false);
+            }
+          }
+        }
+        break;
+      default:
+        throw std::runtime_error("unknown type");
+    }
+  }
+
+  return true;
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::getKeyHashFromROSmessage(
+  const MembersType * members,
+  void * ros_message,
+  eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+  bool force_md5) const
+{
+  assert(members);
+  assert(ros_message);
+
+  // get estimated serialized size in case key is unbounded
+  if (this->key_is_unbounded_)
+  {
+    this->key_max_serialized_size_ = this->getEstimatedSerializedSize(members, ros_message, 0, true);
+    key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
+  eprosima::fastcdr::FastBuffer buffer(
+    reinterpret_cast<char *>(this->key_buffer_.data()),
+    this->key_max_serialized_size_);
+
+  eprosima::fastcdr::Cdr ser(
+    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+  // serialize
+  serializeKeyROSmessage(ser, members_, ros_message, true);
+
+  // check for md5
+  if (force_md5 || this->key_max_serialized_size_ > 16)
+  {
+      md5_.init();
+
+#if FASTCDR_VERSION_MAJOR == 1
+      md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.getSerializedDataLength()));
+#else
+      md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.get_serialized_data_length()));
+#endif // FASTCDR_VERSION_MAJOR == 1
+
+      md5_.finalize();
+
+      for (uint8_t i = 0; i < 16; ++i)
+      {
+          ihandle->value[i] = md5_.digest[i];
+      }
+  }
+  else
+  {
+      for (uint8_t i = 0; i < 16; ++i)
+      {
+          ihandle->value[i] = this->key_buffer_[i];
+      }
+  }
+
+  return true;
+}
+
 // C++ specialization
 template<typename T>
 size_t next_field_align(
@@ -465,7 +626,8 @@ template<typename MembersType>
 size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
   const MembersType * members,
   const void * ros_message,
-  size_t current_alignment) const
+  size_t current_alignment,
+  bool compute_key_members_only) const
 {
   assert(members);
   assert(ros_message);
@@ -475,6 +637,12 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
   for (uint32_t i = 0; i < members->member_count_; ++i) {
     const auto member = members->members_ + i;
     void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
+
+    if (compute_key_members_only && !member->is_key_)
+    {
+      continue;
+    }
+
     switch (member->type_id_) {
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
         current_alignment = next_field_align<bool>(member, field, current_alignment);
@@ -521,7 +689,7 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
-            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment);
+            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment, compute_key_members_only);
           } else {
             size_t array_size = 0;
 
@@ -546,7 +714,8 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
               current_alignment += getEstimatedSerializedSize(
                 sub_members,
                 member->get_function(field, index),
-                current_alignment);
+                current_alignment,
+                compute_key_members_only);
             }
           }
         }
@@ -816,7 +985,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 
 template<typename MembersType>
 size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
-  const MembersType * members, size_t current_alignment)
+  const MembersType * members, size_t current_alignment, size_t& max_serialized_key_size)
 {
   assert(members);
 
@@ -829,6 +998,13 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
     const auto * member = members->members_ + i;
 
     size_t array_size = 1;
+    bool member_is_key = false;
+
+    if (member->is_key_)
+    {
+      member_is_key = true;
+    }
+
     if (member->is_array_) {
       array_size = member->array_size_;
 
@@ -842,6 +1018,12 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         this->is_plain_ = false;
         current_alignment += padding +
           eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+
+        if (member_is_key)
+        {
+          max_serialized_key_size += padding +
+          eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, padding);
+        }
       }
     }
 
@@ -854,12 +1036,22 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
         last_member_size = array_size * sizeof(int8_t);
         current_alignment += array_size * sizeof(int8_t);
+        if (member_is_key)
+        {
+          max_serialized_key_size += array_size * sizeof(uint8_t) +
+          eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, sizeof(uint8_t));
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
         last_member_size = array_size * sizeof(uint16_t);
         current_alignment += array_size * sizeof(uint16_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint16_t));
+        if (member_is_key)
+        {
+          max_serialized_key_size += array_size * sizeof(uint16_t) +
+          eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, sizeof(uint16_t));
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
@@ -867,6 +1059,11 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         last_member_size = array_size * sizeof(uint32_t);
         current_alignment += array_size * sizeof(uint32_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint32_t));
+        if (member_is_key)
+        {
+          max_serialized_key_size += array_size * sizeof(uint32_t) +
+          eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, sizeof(uint32_t));
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
@@ -874,6 +1071,11 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         last_member_size = array_size * sizeof(uint64_t);
         current_alignment += array_size * sizeof(uint64_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint64_t));
+        if (member_is_key)
+        {
+          max_serialized_key_size += array_size * sizeof(uint64_t) +
+          eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, sizeof(uint64_t));
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING:
@@ -886,6 +1088,13 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
             current_alignment += padding +
               eprosima::fastcdr::Cdr::alignment(current_alignment, padding) +
               character_size * (member->string_upper_bound_ + 1);
+            if (member_is_key)
+            {
+              key_is_unbounded_ = true;
+              max_serialized_key_size += padding +
+                eprosima::fastcdr::Cdr::alignment(max_serialized_key_size, padding) +
+                character_size * (member->string_upper_bound_ + 1);
+            }
           }
         }
         break;
@@ -893,9 +1102,16 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           for (size_t index = 0; index < array_size; ++index) {
-            size_t curr = calculateMaxSerializedSize(sub_members, current_alignment);
+            // We set the type as keyed
+            // if any of the parent struct members are keyed
+            size_t dummy_max_serialized_key_size;
+            size_t curr = calculateMaxSerializedSize(sub_members, current_alignment, dummy_max_serialized_key_size);
             current_alignment += curr;
             last_member_size += curr;
+            if (member_is_key)
+            {
+              max_serialized_key_size += curr;
+            }
           }
         }
         break;
@@ -991,6 +1207,25 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
   }
 
   return true;
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+{
+
+  assert(ros_message);
+  assert(members_);
+
+  bool ret = false;
+
+  (void)impl;
+  if (members_->member_count_ != 0)
+  {
+    ret = TypeSupport::getKeyHashFromROSmessage(members_, ros_message, ihandle, force_md5);
+  }
+
+  return ret;
 }
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/src/client_service_common.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/client_service_common.cpp
@@ -20,10 +20,12 @@
 const void *
 get_request_ptr(const void * untyped_service_members, const char * typesupport)
 {
-  if (using_introspection_c_typesupport(typesupport)) {
+  uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+  (void)abi_version;
+  if (using_introspection_c_typesupport(typesupport, abi_version)) {
     return get_request_ptr<rosidl_typesupport_introspection_c__ServiceMembers>(
       untyped_service_members);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
+  } else if (using_introspection_cpp_typesupport(typesupport, abi_version)) {
     return get_request_ptr<rosidl_typesupport_introspection_cpp::ServiceMembers>(
       untyped_service_members);
   }
@@ -34,10 +36,12 @@ get_request_ptr(const void * untyped_service_members, const char * typesupport)
 const void *
 get_response_ptr(const void * untyped_service_members, const char * typesupport)
 {
-  if (using_introspection_c_typesupport(typesupport)) {
+  uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+  (void)abi_version;
+  if (using_introspection_c_typesupport(typesupport, abi_version)) {
     return get_response_ptr<rosidl_typesupport_introspection_c__ServiceMembers>(
       untyped_service_members);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
+  } else if (using_introspection_cpp_typesupport(typesupport, abi_version)) {
     return get_response_ptr<rosidl_typesupport_introspection_cpp::ServiceMembers>(
       untyped_service_members);
   }

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -270,6 +270,14 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
+  }
+
   // Creates DataWriter (with publisher name to not change name policy)
   info->data_writer_ = publisher->create_datawriter(
     info->topic_,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -354,6 +354,14 @@ rmw_create_client(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->response_reader_ = subscriber->create_datareader(
     response_topic_desc,
@@ -410,6 +418,14 @@ rmw_create_client(
   {
     RMW_SET_ERROR_MSG("create_client() failed setting request DataWriter QoS");
     return nullptr;
+  }
+
+  /// Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -353,6 +353,14 @@ rmw_create_service(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->request_reader_ = subscriber->create_datareader(
     request_topic_desc,
@@ -413,6 +421,14 @@ rmw_create_service(
   {
     RMW_SET_ERROR_MSG("create_service() failed setting response DataWriter QoS");
     return nullptr;
+  }
+
+  /// Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -274,6 +274,14 @@ create_subscription(
     return nullptr;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   eprosima::fastdds::dds::DataReaderQos original_qos = reader_qos;
   switch (subscription_options->require_unique_network_flow_endpoints) {
     default:

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_common.cpp
@@ -23,14 +23,35 @@
 #include "type_support_common.hpp"
 
 bool
-using_introspection_c_typesupport(const char * typesupport_identifier)
+using_introspection_c_typesupport(const char * typesupport_identifier, uint8_t &abi_version)
 {
-  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
+  bool ret = false;
+  if (strcmp(typesupport_identifier, rosidl_typesupport_introspection_c__identifier) == 0)
+  {
+    abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+    ret = true;
+
+  } else if (strcmp(typesupport_identifier, rosidl_typesupport_introspection_c__identifier_v2) == 0)
+  {
+    abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V2;
+    ret = true;
+  }
+  return ret;
 }
 
 bool
-using_introspection_cpp_typesupport(const char * typesupport_identifier)
+using_introspection_cpp_typesupport(const char * typesupport_identifier, uint8_t &abi_version)
 {
-  return typesupport_identifier ==
-         rosidl_typesupport_introspection_cpp::typesupport_identifier;
+  bool ret = false;
+  if (strcmp(typesupport_identifier, rosidl_typesupport_introspection_cpp::typesupport_identifier) == 0)
+  {
+    abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+    ret = true;
+
+  } else if (strcmp(typesupport_identifier, rosidl_typesupport_introspection_cpp::typesupport_identifier_v2) == 0)
+  {
+    abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V2;
+    ret = true;
+  }
+  return ret;
 }

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_common.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_common.hpp
@@ -63,10 +63,12 @@ using ResponseTypeSupport_cpp = rmw_fastrtps_dynamic_cpp::ResponseTypeSupport<
 >;
 
 bool
-using_introspection_c_typesupport(const char * typesupport_identifier);
+using_introspection_c_typesupport(const char * typesupport_identifier,
+                                  uint8_t& abi_version);
 
 bool
-using_introspection_cpp_typesupport(const char * typesupport_identifier);
+using_introspection_cpp_typesupport(const char * typesupport_identifier,
+                                  uint8_t& abi_version);
 
 template<typename MembersType>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_LOCAL
@@ -98,10 +100,12 @@ _create_type_name(
   const void * untyped_members,
   const char * typesupport)
 {
-  if (using_introspection_c_typesupport(typesupport)) {
+  uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+  (void)abi_version;
+  if (using_introspection_c_typesupport(typesupport, abi_version)) {
     return _create_type_name<rosidl_typesupport_introspection_c__MessageMembers>(
       untyped_members);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
+  } else if (using_introspection_cpp_typesupport(typesupport, abi_version)) {
     return _create_type_name<rosidl_typesupport_introspection_cpp::MessageMembers>(
       untyped_members);
   }

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
@@ -23,6 +23,7 @@ TypeSupportProxy::TypeSupportProxy(rmw_fastrtps_shared_cpp::TypeSupport * inner_
   m_typeSize = inner_type->m_typeSize;
   is_plain_ = inner_type->is_plain();
   max_size_bound_ = inner_type->is_bounded();
+  m_isGetKeyDefined = inner_type->m_isGetKeyDefined;
 }
 
 size_t TypeSupportProxy::getEstimatedSerializedSize(
@@ -44,6 +45,13 @@ bool TypeSupportProxy::deserializeROSmessage(
 {
   auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);
   return type_impl->deserializeROSmessage(deser, ros_message, impl);
+}
+
+bool TypeSupportProxy::getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+{
+  auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);
+  return type_impl->getKeyHashFromROSmessage(ros_message, ihandle, force_md5, impl);
 }
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_registry.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_registry.cpp
@@ -81,14 +81,18 @@ type_support_ptr TypeSupportRegistry::get_message_type_support(
 {
   auto creator_fun = [&ros_type_support]() -> type_support_ptr
     {
-      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier)) {
+      uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
           ros_type_support->data);
-        return new MessageTypeSupport_c(members, ros_type_support);
-      } else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier)) {
+        return new MessageTypeSupport_c(members, ros_type_support, abi_version);
+      }
+      else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
           ros_type_support->data);
-        return new MessageTypeSupport_cpp(members, ros_type_support);
+        return new MessageTypeSupport_cpp(members, ros_type_support, abi_version);
       }
       RMW_SET_ERROR_MSG("Unknown typesupport identifier");
       return nullptr;
@@ -102,14 +106,18 @@ type_support_ptr TypeSupportRegistry::get_request_type_support(
 {
   auto creator_fun = [&ros_type_support]() -> type_support_ptr
     {
-      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier)) {
+      uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
           ros_type_support->data);
-        return new RequestTypeSupport_c(members, ros_type_support);
-      } else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier)) {
+        return new RequestTypeSupport_c(members, ros_type_support, abi_version);
+      }
+      else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
           ros_type_support->data);
-        return new RequestTypeSupport_cpp(members, ros_type_support);
+        return new RequestTypeSupport_cpp(members, ros_type_support, abi_version);
       }
       RMW_SET_ERROR_MSG("Unknown typesupport identifier");
       return nullptr;
@@ -123,14 +131,18 @@ type_support_ptr TypeSupportRegistry::get_response_type_support(
 {
   auto creator_fun = [&ros_type_support]() -> type_support_ptr
     {
-      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier)) {
+      uint8_t abi_version = rmw_fastrtps_shared_cpp::TypeSupport::AbiVersion::ABI_V1;
+      if (using_introspection_c_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
           ros_type_support->data);
-        return new ResponseTypeSupport_c(members, ros_type_support);
-      } else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier)) {
+        return new ResponseTypeSupport_c(members, ros_type_support, abi_version);
+      }
+      else if (using_introspection_cpp_typesupport(ros_type_support->typesupport_identifier, abi_version))
+      {
         auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
           ros_type_support->data);
-        return new ResponseTypeSupport_cpp(members, ros_type_support);
+        return new ResponseTypeSupport_cpp(members, ros_type_support, abi_version);
       }
       RMW_SET_ERROR_MSG("Unknown typesupport identifier");
       return nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -54,6 +54,13 @@ struct SerializedData
 class TypeSupport : public eprosima::fastdds::dds::TopicDataType
 {
 public:
+
+  enum AbiVersion
+  {
+    ABI_V1 = 1,
+    ABI_V2
+  };
+
   virtual size_t getEstimatedSerializedSize(const void * ros_message, const void * impl) const = 0;
 
   virtual bool serializeROSmessage(
@@ -111,6 +118,7 @@ protected:
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   TypeSupport();
 
+  mutable uint8_t abi_version_;
   bool max_size_bound_;
   bool is_plain_;
   bool key_is_unbounded_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -61,15 +61,14 @@ public:
   virtual bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const = 0;
 
+  virtual bool getKeyHashFromROSmessage(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const = 0;
+
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool getKey(
     void * data,
     eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
-    bool force_md5 = false) override
-  {
-    (void)data; (void)ihandle; (void)force_md5;
-    return false;
-  }
+    bool force_md5 = false) override;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool serialize(void * data, eprosima::fastrtps::rtps::SerializedPayload_t * payload) override;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -25,6 +25,7 @@
 
 #include "fastcdr/FastBuffer.h"
 #include "fastcdr/Cdr.h"
+#include "fastrtps/utils/md5.h"
 
 #include "rcutils/logging_macros.h"
 
@@ -112,6 +113,10 @@ protected:
 
   bool max_size_bound_;
   bool is_plain_;
+  bool key_is_unbounded_;
+  mutable size_t key_max_serialized_size_;
+  mutable MD5 md5_;
+  mutable std::vector<uint8_t> key_buffer_;
 };
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
@@ -126,6 +126,22 @@ create_datareader(
   CustomDataReaderListener * listener,
   eprosima::fastdds::dds::DataReader ** data_reader);
 
+
+/**
+* Apply specific resource limits when using keys.
+* Max samples per instance is set to history depth if KEEP_LAST
+* else UNLIMITED.
+*
+* \param[in]       hitory_qos       History entitiy QoS.
+* \param[in, out]  res_limits_qos   Resource limits entitiy QoS.
+*
+*/
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+void
+apply_qos_resource_limits_for_keys(
+  const eprosima::fastdds::dds::HistoryQosPolicy & history_qos,
+  eprosima::fastdds::dds::ResourceLimitsQosPolicy & res_limits_qos);
+
 }  // namespace rmw_fastrtps_shared_cpp
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__UTILS_HPP_

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -64,6 +64,50 @@ void * TypeSupport::createData()
   return new eprosima::fastcdr::FastBuffer();
 }
 
+bool TypeSupport::getKey(
+    void * data,
+    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    bool force_md5)
+{
+  assert(data);
+
+  bool ret = false;
+
+  if (!m_isGetKeyDefined)
+  {
+      return ret;
+  }
+
+  auto ser_data = static_cast<SerializedData *>(data);
+
+  switch (ser_data->type)
+  {
+    case FASTRTPS_SERIALIZED_DATA_TYPE_ROS_MESSAGE:
+      {
+        ret = this->getKeyHashFromROSmessage(ser_data->data, ihandle, force_md5, ser_data->impl);
+        break;
+      }
+
+    case FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER:
+      {
+        //! TODO
+        break;
+      }
+
+    case FASTRTPS_SERIALIZED_DATA_TYPE_DYNAMIC_MESSAGE:
+      {
+        //! TODO
+        break;
+      }
+    default:
+      {
+        break;
+      }
+  }
+
+  return ret;
+}
+
 bool TypeSupport::serialize(
   void * data, eprosima::fastrtps::rtps::SerializedPayload_t * payload)
 {

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -167,6 +167,14 @@ __rmw_subscription_set_content_filter(
     des_topic = info->topic_;
   }
 
+  /// Apply resource limits QoS if the type is keyed
+  if (info->type_support_->m_isGetKeyDefined)
+  {
+    apply_qos_resource_limits_for_keys(
+      info->datareader_qos_.history(),
+      info->datareader_qos_.resource_limits());
+  }
+
   // create data reader
   eprosima::fastdds::dds::Subscriber * subscriber = info->subscriber_;
   const rmw_subscription_options_t * subscription_options =

--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -180,5 +180,21 @@ create_datareader(
   return true;
 }
 
+void
+apply_qos_resource_limits_for_keys(
+  const eprosima::fastdds::dds::HistoryQosPolicy & history_qos,
+  eprosima::fastdds::dds::ResourceLimitsQosPolicy & res_limits_qos)
+{
+  res_limits_qos.max_instances = 0;
+  res_limits_qos.max_samples = 0;
+  if (history_qos.kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+  {
+    res_limits_qos.max_samples_per_instance = history_qos.depth;
+  }
+  else
+  {
+    res_limits_qos.max_samples_per_instance = 0;
+  }
+}
 
 }  // namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
This PR brings the `topic keys feature`  without breaking `ABI`. This means that the current version supports legacy message types of old generators thanks to a new `typesupport_identifier`

_Note: This branch starts from the previous work from https://github.com/eProsima/rmw_fastrtps/pull/19_