### PR TITLE
[21603] Additional fixes for building with Fast DDS 3.0

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -38,10 +38,8 @@ find_package(rmw_dds_common REQUIRED)
 find_package(rmw_fastrtps_shared_cpp REQUIRED)
 find_package(tracetools REQUIRED)
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3 REQUIRED CONFIG)
-find_package(FastDDS 3 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 find_package(rmw REQUIRED)
 find_package(rosidl_dynamic_typesupport REQUIRED)

--- a/rmw_fastrtps_cpp/package.xml
+++ b/rmw_fastrtps_cpp/package.xml
@@ -16,13 +16,11 @@
   <author>Ricardo González</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <build_depend>fastcdr</build_depend>
   <build_depend>fastdds</build_depend>
-  <build_depend>fastrtps_cmake_module</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -38,7 +36,6 @@
 
   <build_export_depend>fastcdr</build_export_depend>
   <build_export_depend>fastdds</build_export_depend>
-  <build_export_depend>fastrtps_cmake_module</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw_dds_common</build_export_depend>
   <build_export_depend>rmw_fastrtps_shared_cpp</build_export_depend>

--- a/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
+++ b/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
@@ -14,10 +14,8 @@
 
 # copied from rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3 REQUIRED CONFIG)
-find_package(FastDDS 3 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 list(APPEND rmw_fastrtps_cpp_INCLUDE_DIRS ${FAST_INCLUDE_DIR})
 # specific order: dependents before dependencies

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -37,10 +37,8 @@ find_package(rcutils REQUIRED)
 find_package(rmw_dds_common REQUIRED)
 find_package(rmw_fastrtps_shared_cpp REQUIRED)
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3 REQUIRED CONFIG)
-find_package(FastDDS 3 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 find_package(rmw REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)

--- a/rmw_fastrtps_dynamic_cpp/package.xml
+++ b/rmw_fastrtps_dynamic_cpp/package.xml
@@ -16,13 +16,11 @@
   <author>Ricardo González</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <build_depend>fastcdr</build_depend>
   <build_depend>fastdds</build_depend>
-  <build_depend>fastrtps_cmake_module</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -34,7 +32,6 @@
 
   <build_export_depend>fastcdr</build_export_depend>
   <build_export_depend>fastdds</build_export_depend>
-  <build_export_depend>fastrtps_cmake_module</build_export_depend>
   <build_export_depend>rcpputils</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw</build_export_depend>

--- a/rmw_fastrtps_dynamic_cpp/rmw_fastrtps_dynamic_cpp-extras.cmake
+++ b/rmw_fastrtps_dynamic_cpp/rmw_fastrtps_dynamic_cpp-extras.cmake
@@ -14,10 +14,8 @@
 
 # copied from rmw_fastrtps_dynamic_cpp/rmw_fastrtps_dynamic_cpp-extras.cmake
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3 REQUIRED CONFIG)
-find_package(FastDDS 3 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 list(APPEND rmw_fastrtps_dynamic_cpp_INCLUDE_DIRS ${FAST_INCLUDE_DIR})
 # specific order: dependents before dependencies

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -45,10 +45,8 @@ find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 find_package(tracetools REQUIRED)
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3 REQUIRED CONFIG)
-find_package(FastDDS 3 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 find_package(rmw REQUIRED)
 

--- a/rmw_fastrtps_shared_cpp/Doxyfile
+++ b/rmw_fastrtps_shared_cpp/Doxyfile
@@ -17,7 +17,7 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             = RMW_FASTDDS_SHARED_CPP_PUBLIC=
+PREDEFINED             = RMW_FASTRTPS_SHARED_CPP_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -60,7 +60,7 @@ public:
   virtual bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const = 0;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool compute_key(
     const void * const data,
     eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
@@ -70,7 +70,7 @@ public:
     return false;
   }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool compute_key(
     eprosima::fastdds::rtps::SerializedPayload_t & data,
     eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
@@ -80,28 +80,28 @@ public:
     return false;
   }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool serialize(
     const void * const data,
     eprosima::fastdds::rtps::SerializedPayload_t & payload,
     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool deserialize(eprosima::fastdds::rtps::SerializedPayload_t & payload, void * data) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   uint32_t calculate_serialized_size(
     const void * const data,
     eprosima::fastdds::dds::DataRepresentationId_t data_representation)
   override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void * create_data() override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void delete_data(void * data) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   inline bool is_bounded() const
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
   override
@@ -110,25 +110,25 @@ public:
     return max_size_bound_;
   }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   inline bool is_plain(eprosima::fastdds::dds::DataRepresentationId_t rep) const override
   {
     return is_plain_ && rep == eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
   }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC void register_type_object_representation() override;
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC void register_type_object_representation() override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   inline const rosidl_message_type_support_t * ros_message_type_supports() const
   {
     return type_supports_;
   }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   virtual ~TypeSupport() {}
 
 protected:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   TypeSupport(
     const rosidl_message_type_support_t * type_supports
   );

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/create_rmw_gid.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/create_rmw_gid.hpp
@@ -24,7 +24,7 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_gid_t
 create_rmw_gid(const char * identifier, const eprosima::fastdds::rtps::GUID_t & guid);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -61,19 +61,19 @@ enum class publishing_mode_t
 class CustomTopicListener final : public eprosima::fastdds::dds::TopicListener
 {
 public:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   explicit CustomTopicListener(EventListenerInterface * event_listener);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   on_inconsistent_topic(
     eprosima::fastdds::dds::Topic * topic,
     eprosima::fastdds::dds::InconsistentTopicStatus status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void add_event_listener(EventListenerInterface * event_listener);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void remove_event_listener(EventListenerInterface * event_listener);
 
 private:
@@ -117,14 +117,14 @@ typedef struct CustomParticipantInfo
   bool leave_middleware_default_qos;
   publishing_mode_t publishing_mode;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   eprosima::fastdds::dds::Topic * find_or_create_topic(
     const std::string & topic_name,
     const std::string & type_name,
     const eprosima::fastdds::dds::TopicQos & topic_qos,
     EventListenerInterface * event_listener);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void delete_topic(
     const eprosima::fastdds::dds::Topic * topic,
     EventListenerInterface * event_listener);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -41,28 +41,28 @@ class RMWPublisherEvent;
 class CustomDataWriterListener final : public eprosima::fastdds::dds::DataWriterListener
 {
 public:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   explicit CustomDataWriterListener(RMWPublisherEvent * pub_event);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   on_publication_matched(
     eprosima::fastdds::dds::DataWriter * writer,
     const eprosima::fastdds::dds::PublicationMatchedStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   on_offered_deadline_missed(
     eprosima::fastdds::dds::DataWriter * writer,
     const eprosima::fastdds::dds::OfferedDeadlineMissedStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   on_liveliness_lost(
     eprosima::fastdds::dds::DataWriter * writer,
     const eprosima::fastdds::dds::LivelinessLostStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   on_offered_incompatible_qos(
     eprosima::fastdds::dds::DataWriter *,
@@ -86,7 +86,7 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
 
   eprosima::fastdds::dds::Topic * topic_{nullptr};
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *
   get_listener() const final;
 } CustomPublisherInfo;
@@ -94,24 +94,24 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
 class RMWPublisherEvent final : public EventListenerInterface
 {
 public:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   explicit RMWPublisherEvent(CustomPublisherInfo * info);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   eprosima::fastdds::dds::StatusCondition & get_statuscondition() const override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool take_event(
     rmw_event_type_t event_type,
     void * event_info) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void set_on_new_event_callback(
     rmw_event_type_t event_type,
     const void * user_data,
     rmw_event_callback_t callback) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_inconsistent_topic(uint32_t total_count, uint32_t total_count_change) override;
 
   /// Add a GUID to the internal set of unique subscriptions matched to this publisher.
@@ -121,7 +121,7 @@ public:
    *
    * \param[in] guid The GUID of the newly-matched subscription to track.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void track_unique_subscription(eprosima::fastdds::rtps::GUID_t guid);
 
   /// Remove a GUID from the internal set of unique subscriptions matched to this publisher.
@@ -131,28 +131,28 @@ public:
    *
    * \param[in] guid The GUID of the newly-unmatched subscription to track.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void untrack_unique_subscription(eprosima::fastdds::rtps::GUID_t guid);
 
   /// Return the number of unique subscriptions matched to this publisher.
   /**
    * \return Number of unique subscriptions matched to this publisher.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   size_t subscription_count() const;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_deadline(uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_liveliness_lost(uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_offered_incompatible_qos(
     eprosima::fastdds::dds::QosPolicyId_t last_policy_id,
     uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_matched(
     int32_t total_count,
     int32_t total_count_change,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -49,34 +49,34 @@ class RMWSubscriptionEvent;
 class CustomDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
 {
 public:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   explicit CustomDataReaderListener(RMWSubscriptionEvent * sub_event);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_subscription_matched(
     eprosima::fastdds::dds::DataReader * reader,
     const eprosima::fastdds::dds::SubscriptionMatchedStatus & info) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_data_available(
     eprosima::fastdds::dds::DataReader * reader) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_requested_deadline_missed(
     eprosima::fastdds::dds::DataReader * reader,
     const eprosima::fastdds::dds::RequestedDeadlineMissedStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_liveliness_changed(
     eprosima::fastdds::dds::DataReader * reader,
     const eprosima::fastdds::dds::LivelinessChangedStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_sample_lost(
     eprosima::fastdds::dds::DataReader * reader,
     const eprosima::fastdds::dds::SampleLostStatus & status) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void on_requested_incompatible_qos(
     eprosima::fastdds::dds::DataReader * reader,
     const eprosima::fastdds::dds::RequestedIncompatibleQosStatus & status) override;
@@ -113,7 +113,7 @@ struct CustomSubscriberInfo : public CustomEventInfo
   eprosima::fastdds::dds::ContentFilteredTopic * filtered_topic_ {nullptr};
   eprosima::fastdds::dds::DataReaderQos datareader_qos_;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *
   get_listener() const final;
 };
@@ -122,26 +122,26 @@ struct CustomSubscriberInfo : public CustomEventInfo
 class RMWSubscriptionEvent final : public EventListenerInterface
 {
 public:
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   explicit RMWSubscriptionEvent(CustomSubscriberInfo * info);
 
   // Provide handlers to perform an action when a
   // new event from this listener has occurred
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void
   set_on_new_message_callback(
     const void * user_data,
     rmw_event_callback_t callback);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   eprosima::fastdds::dds::StatusCondition & get_statuscondition() const override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool take_event(
     rmw_event_type_t event_type,
     void * event_info) override;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void set_on_new_event_callback(
     rmw_event_type_t event_type,
     const void * user_data,
@@ -163,7 +163,7 @@ public:
   //                     elsewhere (e.g. to check for listener initialization status), which is
   // }
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_inconsistent_topic(uint32_t total_count, uint32_t total_count_change) override;
 
   /// Add a GUID to the internal set of unique publishers matched to this subscription.
@@ -173,7 +173,7 @@ public:
    *
    * \param[in] guid The GUID of the newly-matched publisher to track.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void track_unique_publisher(eprosima::fastdds::rtps::GUID_t guid);
 
   /// Remove a GUID from the internal set of unique publishers matched to this subscription.
@@ -183,36 +183,36 @@ public:
    *
    * \param[in] guid The GUID of the newly-unmatched publisher to track.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void untrack_unique_publisher(eprosima::fastdds::rtps::GUID_t guid);
 
   /// Return the number of unique publishers matched to this subscription.
   /**
    * \return Number of unique publishers matched to this subscription.
    */
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   size_t publisher_count() const;
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_data_available();
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_requested_deadline_missed(uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_liveliness_changed(
     uint32_t alive_count, uint32_t not_alive_count,
     uint32_t alive_count_change, uint32_t not_alive_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_sample_lost(uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_requested_incompatible_qos(
     eprosima::fastdds::dds::QosPolicyId_t last_policy_id,
     uint32_t total_count, uint32_t total_count_change);
 
-  RMW_FASTDDS_SHARED_CPP_PUBLIC
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_matched(
     int32_t total_count,
     int32_t total_count_change,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/init_rmw_context_impl.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/init_rmw_context_impl.hpp
@@ -27,7 +27,7 @@ namespace rmw_fastrtps_shared_cpp
 /**
  * Function that should be called when destroying a node.
  */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 decrement_context_impl_ref_count(rmw_context_t * context);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/listener_thread.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/listener_thread.hpp
@@ -22,11 +22,11 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 run_listener_thread(rmw_context_t * context);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 join_listener_thread(rmw_context_t * context);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/namespace_prefix.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/namespace_prefix.hpp
@@ -22,11 +22,11 @@
 
 extern "C"
 {
-RMW_FASTDDS_SHARED_CPP_PUBLIC extern const char * const ros_topic_prefix;
-RMW_FASTDDS_SHARED_CPP_PUBLIC extern const char * const ros_service_requester_prefix;
-RMW_FASTDDS_SHARED_CPP_PUBLIC extern const char * const ros_service_response_prefix;
+RMW_FASTRTPS_SHARED_CPP_PUBLIC extern const char * const ros_topic_prefix;
+RMW_FASTRTPS_SHARED_CPP_PUBLIC extern const char * const ros_service_requester_prefix;
+RMW_FASTRTPS_SHARED_CPP_PUBLIC extern const char * const ros_service_response_prefix;
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC extern const std::vector<std::string> _ros_prefixes;
+RMW_FASTRTPS_SHARED_CPP_PUBLIC extern const std::vector<std::string> _ros_prefixes;
 }  // extern "C"
 
 /// Returns `name` stripped of `prefix` if exists, if not return "".
@@ -36,22 +36,22 @@ RMW_FASTDDS_SHARED_CPP_PUBLIC extern const std::vector<std::string> _ros_prefixe
  * \return name stripped of prefix, or
  * \return "" if name doesn't start with prefix
  */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 std::string
 _resolve_prefix(const std::string & name, const std::string & prefix);
 
 /// Return the ROS specific prefix if it exists, otherwise "".
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 std::string
 _get_ros_prefix_if_exists(const std::string & topic_name);
 
 /// Returns the topic name stripped of and ROS specific prefix if exists.
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 std::string
 _strip_ros_prefix_if_exists(const std::string & topic_name);
 
 /// Returns the list of ros prefixes
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 const std::vector<std::string> &
 _get_all_ros_prefixes();
 #endif  // RMW_FASTRTPS_SHARED_CPP__NAMESPACE_PREFIX_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/participant.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/participant.hpp
@@ -31,7 +31,7 @@ namespace rmw_fastrtps_shared_cpp
 // For the creation of DDS DataReader see method create_subscription
 // Note that ROS 2 Publishers and Subscriptions correspond with DDS DataWriters
 // and DataReaders respectively and not with DDS Publishers and Subscribers.
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 CustomParticipantInfo *
 create_participant(
   const char * identifier,
@@ -41,7 +41,7 @@ create_participant(
   const char * enclave,
   rmw_dds_common::Context * common_context);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 destroy_participant(CustomParticipantInfo * info);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/publisher.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/publisher.hpp
@@ -22,7 +22,7 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 destroy_publisher(
   const char * identifier,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -27,31 +27,31 @@
 
 #include "rosidl_runtime_c/type_hash.h"
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 is_valid_qos(const rmw_qos_profile_t & qos_policies);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 get_datareader_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataReaderQos & reader_qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 get_datawriter_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataWriterQos & writer_qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 get_topic_qos(
   const rmw_qos_profile_t & qos_policies,
   eprosima::fastdds::dds::TopicQos & topic_qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_time_t
 dds_duration_to_rmw(const eprosima::fastdds::dds::Duration_t & duration);
 
@@ -177,12 +177,12 @@ rtps_qos_to_rmw_qos(
   qos->liveliness_lease_duration = dds_duration_to_rmw(rtps_qos.liveliness.lease_duration);
 }
 
-extern template RMW_FASTDDS_SHARED_CPP_PUBLIC
+extern template RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void dds_qos_to_rmw_qos<eprosima::fastdds::dds::DataWriterQos>(
   const eprosima::fastdds::dds::DataWriterQos & dds_qos,
   rmw_qos_profile_t * qos);
 
-extern template RMW_FASTDDS_SHARED_CPP_PUBLIC
+extern template RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void dds_qos_to_rmw_qos<eprosima::fastdds::dds::DataReaderQos>(
   const eprosima::fastdds::dds::DataReaderQos & dds_qos,
   rmw_qos_profile_t * qos);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -32,14 +32,14 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_client(
   const char * identifier,
   rmw_node_t * node,
   rmw_client_t * client);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_compare_gids_equal(
   const char * identifier,
@@ -47,7 +47,7 @@ __rmw_compare_gids_equal(
   const rmw_gid_t * gid2,
   bool * result);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_count_publishers(
   const char * identifier,
@@ -55,7 +55,7 @@ __rmw_count_publishers(
   const char * topic_name,
   size_t * count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_count_subscribers(
   const char * identifier,
@@ -63,7 +63,7 @@ __rmw_count_subscribers(
   const char * topic_name,
   size_t * count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_count_clients(
   const char * identifier,
@@ -71,7 +71,7 @@ __rmw_count_clients(
   const char * service_name,
   size_t * count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_count_services(
   const char * identifier,
@@ -79,39 +79,39 @@ __rmw_count_services(
   const char * service_name,
   size_t * count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_gid_for_publisher(
   const char * identifier,
   const rmw_publisher_t * publisher,
   rmw_gid_t * gid);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_gid_for_client(
   const char * identifier,
   const rmw_client_t * client,
   rmw_gid_t * gid);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_guard_condition_t *
 __rmw_create_guard_condition(const char * identifier);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_guard_condition(rmw_guard_condition_t * guard_condition);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_trigger_guard_condition(
   const char * identifier,
   const rmw_guard_condition_t * guard_condition_handle);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_set_log_severity(rmw_log_severity_t severity);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_node_t *
 __rmw_create_node(
   rmw_context_t * context,
@@ -119,17 +119,17 @@ __rmw_create_node(
   const char * name,
   const char * namespace_);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_node(
   const char * identifier,
   rmw_node_t * node);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 const rmw_guard_condition_t *
 __rmw_node_get_graph_guard_condition(const rmw_node_t * node);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_node_names(
   const char * identifier,
@@ -137,7 +137,7 @@ __rmw_get_node_names(
   rcutils_string_array_t * node_names,
   rcutils_string_array_t * node_namespaces);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_init_event(
   const char * identifier,
@@ -146,7 +146,7 @@ __rmw_init_event(
   void * data,
   rmw_event_type_t event_type);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_node_names_with_enclaves(
   const char * identifier,
@@ -155,7 +155,7 @@ __rmw_get_node_names_with_enclaves(
   rcutils_string_array_t * node_namespaces,
   rcutils_string_array_t * enclaves);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publish(
   const char * identifier,
@@ -163,7 +163,7 @@ __rmw_publish(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publish_serialized_message(
   const char * identifier,
@@ -171,7 +171,7 @@ __rmw_publish_serialized_message(
   const rmw_serialized_message_t * serialized_message,
   rmw_publisher_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_borrow_loaned_message(
   const char * identifier,
@@ -179,14 +179,14 @@ __rmw_borrow_loaned_message(
   const rosidl_message_type_support_t * type_support,
   void ** ros_message);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_return_loaned_message_from_publisher(
   const char * identifier,
   const rmw_publisher_t * publisher,
   void * loaned_message);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publish_loaned_message(
   const char * identifier,
@@ -194,39 +194,39 @@ __rmw_publish_loaned_message(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publisher_assert_liveliness(
   const char * identifier,
   const rmw_publisher_t * publisher);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publisher_wait_for_all_acked(
   const char * identifier,
   const rmw_publisher_t * publisher,
   rmw_time_t wait_timeout);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_publisher(
   const char * identifier,
   const rmw_node_t * node,
   rmw_publisher_t * publisher);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publisher_count_matched_subscriptions(
   const rmw_publisher_t * publisher,
   size_t * subscription_count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publisher_get_actual_qos(
   const rmw_publisher_t * publisher,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_send_request(
   const char * identifier,
@@ -234,7 +234,7 @@ __rmw_send_request(
   const void * ros_request,
   int64_t * sequence_id);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_request(
   const char * identifier,
@@ -243,7 +243,7 @@ __rmw_take_request(
   void * ros_request,
   bool * taken);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_response(
   const char * identifier,
@@ -252,7 +252,7 @@ __rmw_take_response(
   void * ros_response,
   bool * taken);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_send_response(
   const char * identifier,
@@ -260,14 +260,14 @@ __rmw_send_response(
   rmw_request_id_t * request_header,
   void * ros_response);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_service(
   const char * identifier,
   rmw_node_t * node,
   rmw_service_t * service);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_service_names_and_types(
   const char * identifier,
@@ -275,7 +275,7 @@ __rmw_get_service_names_and_types(
   rcutils_allocator_t * allocator,
   rmw_names_and_types_t * service_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_publisher_names_and_types_by_node(
   const char * identifier,
@@ -286,7 +286,7 @@ __rmw_get_publisher_names_and_types_by_node(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_service_names_and_types_by_node(
   const char * identifier,
@@ -296,7 +296,7 @@ __rmw_get_service_names_and_types_by_node(
   const char * node_namespace,
   rmw_names_and_types_t * service_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_client_names_and_types_by_node(
   const char * identifier,
@@ -306,7 +306,7 @@ __rmw_get_client_names_and_types_by_node(
   const char * node_namespace,
   rmw_names_and_types_t * service_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_subscriber_names_and_types_by_node(
   const char * identifier,
@@ -317,7 +317,7 @@ __rmw_get_subscriber_names_and_types_by_node(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_service_server_is_available(
   const char * identifier,
@@ -325,7 +325,7 @@ __rmw_service_server_is_available(
   const rmw_client_t * client,
   bool * is_available);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_subscription(
   const char * identifier,
@@ -333,56 +333,56 @@ __rmw_destroy_subscription(
   rmw_subscription_t * subscription,
   bool reset_cft = false);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_count_matched_publishers(
   const rmw_subscription_t * subscription,
   size_t * publisher_count);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_get_actual_qos(
   const rmw_subscription_t * subscription,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_set_content_filter(
   rmw_subscription_t * subscription,
   const rmw_subscription_content_filter_options_t * options);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_get_content_filter(
   const rmw_subscription_t * subscription,
   rcutils_allocator_t * allocator,
   rmw_subscription_content_filter_options_t * options);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_service_response_publisher_get_actual_qos(
   const rmw_service_t * service,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_service_request_subscription_get_actual_qos(
   const rmw_service_t * service,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_client_request_publisher_get_actual_qos(
   const rmw_client_t * client,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_client_response_subscription_get_actual_qos(
   const rmw_client_t * client,
   rmw_qos_profile_t * qos);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take(
   const char * identifier,
@@ -391,7 +391,7 @@ __rmw_take(
   bool * taken,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_sequence(
   const char * identifier,
@@ -402,7 +402,7 @@ __rmw_take_sequence(
   size_t * taken,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_loaned_message_internal(
   const char * identifier,
@@ -411,14 +411,14 @@ __rmw_take_loaned_message_internal(
   bool * taken,
   rmw_message_info_t * message_info);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_return_loaned_message_from_subscription(
   const char * identifier,
   const rmw_subscription_t * subscription,
   void * loaned_message);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_event(
   const char * identifier,
@@ -426,7 +426,7 @@ __rmw_take_event(
   void * event_info,
   bool * taken);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_with_info(
   const char * identifier,
@@ -436,7 +436,7 @@ __rmw_take_with_info(
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_serialized_message(
   const char * identifier,
@@ -445,7 +445,7 @@ __rmw_take_serialized_message(
   bool * taken,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_serialized_message_with_info(
   const char * identifier,
@@ -455,7 +455,7 @@ __rmw_take_serialized_message_with_info(
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_dynamic_message(
   const char * identifier,
@@ -464,7 +464,7 @@ __rmw_take_dynamic_message(
   bool * taken,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_take_dynamic_message_with_info(
   const char * identifier,
@@ -474,7 +474,7 @@ __rmw_take_dynamic_message_with_info(
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_topic_names_and_types(
   const char * identifier,
@@ -483,7 +483,7 @@ __rmw_get_topic_names_and_types(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_wait(
   const char * identifier,
@@ -495,15 +495,15 @@ __rmw_wait(
   rmw_wait_set_t * wait_set,
   const rmw_time_t * wait_timeout);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_wait_set_t *
 __rmw_create_wait_set(const char * identifier, rmw_context_t * context, size_t max_conditions);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_wait_set(const char * identifier, rmw_wait_set_t * wait_set);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_publishers_info_by_topic(
   const char * identifier,
@@ -513,7 +513,7 @@ __rmw_get_publishers_info_by_topic(
   bool no_mangle,
   rmw_topic_endpoint_info_array_t * publishers_info);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_get_subscriptions_info_by_topic(
   const char * identifier,
@@ -523,7 +523,7 @@ __rmw_get_subscriptions_info_by_topic(
   bool no_mangle,
   rmw_topic_endpoint_info_array_t * subscriptions_info);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_qos_profile_check_compatible(
   const rmw_qos_profile_t publisher_profile,
@@ -532,49 +532,49 @@ __rmw_qos_profile_check_compatible(
   char * reason,
   size_t reason_size);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publisher_get_network_flow_endpoints(
   const rmw_publisher_t * publisher,
   rcutils_allocator_t * allocator,
   rmw_network_flow_endpoint_array_t * network_flow_endpoint_array);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_get_network_flow_endpoints(
   const rmw_subscription_t * subscription,
   rcutils_allocator_t * allocator,
   rmw_network_flow_endpoint_array_t * network_flow_endpoint_array);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_subscription_set_on_new_message_callback(
   rmw_subscription_t * rmw_subscription,
   rmw_event_callback_t callback,
   const void * user_data);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_service_set_on_new_request_callback(
   rmw_service_t * rmw_service,
   rmw_event_callback_t callback,
   const void * user_data);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_client_set_on_new_response_callback(
   rmw_client_t * rmw_client,
   rmw_event_callback_t callback,
   const void * user_data);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_event_set_callback(
   rmw_event_t * rmw_event,
   rmw_event_callback_t callback,
   const void * user_data);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 __rmw_feature_supported(rmw_feature_t feature);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_init.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_init.hpp
@@ -24,17 +24,17 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 rmw_init_options_init(
   const char * identifier, rmw_init_options_t * init_options, rcutils_allocator_t allocator);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 rmw_init_options_copy(
   const char * identifier, const rmw_init_options_t * src, rmw_init_options_t * dst);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 rmw_init_options_fini(const char * identifier, rmw_init_options_t * init_options);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_security_logging.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_security_logging.hpp
@@ -25,7 +25,7 @@
  * \returns false if the requested configuration could not be applied (rmw error will be set).
  * \returns true if the requested configuration was applied (or no configuration was requested).
  */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool apply_security_logging_configuration(eprosima::fastdds::rtps::PropertyPolicy & policy);
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__RMW_SECURITY_LOGGING_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/subscription.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/subscription.hpp
@@ -22,12 +22,12 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void
 __init_subscription_for_loans(
   rmw_subscription_t * subscription);
 
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 destroy_subscription(
   const char * identifier,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
@@ -38,7 +38,7 @@ namespace rmw_fastrtps_shared_cpp
 * \param[in] code The Fast DDS return code to be translated
 * \return the corresponding rmw_ret_t value
 */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 cast_error_dds_to_rmw(eprosima::fastdds::dds::ReturnCode_t code);
 
@@ -55,7 +55,7 @@ cast_error_dds_to_rmw(eprosima::fastdds::dds::ReturnCode_t code);
 * \return true when there is no such conflict. Returned topic and type may be null
 *              if they were not previously registered on the participant.
 */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 find_and_check_topic_and_type(
   const CustomParticipantInfo * participant_info,
@@ -72,7 +72,7 @@ find_and_check_topic_and_type(
 * \param[in] topic            Topic of the entity being deleted.
 * \param[in] type             TypeSupport of the entity being deleted.
 */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void
 remove_topic_and_type(
   CustomParticipantInfo * participant_info,
@@ -93,7 +93,7 @@ remove_topic_and_type(
 * \return true when the content filtered topic was created
 * \return false when the content filtered topic could not be created
 */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 create_content_filtered_topic(
   eprosima::fastdds::dds::DomainParticipant * participant,
@@ -116,7 +116,7 @@ create_content_filtered_topic(
 * \return true when the data reader was created
 * \return false when the data reader could not be created
 */
-RMW_FASTDDS_SHARED_CPP_PUBLIC
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 create_datareader(
   const eprosima::fastdds::dds::DataReaderQos & datareader_qos,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/visibility_control.h
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/visibility_control.h
@@ -27,30 +27,30 @@
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef __GNUC__
-    #define RMW_FASTDDS_SHARED_CPP_EXPORT __attribute__ ((dllexport))
-    #define RMW_FASTDDS_SHARED_CPP_IMPORT __attribute__ ((dllimport))
+    #define RMW_FASTRTPS_SHARED_CPP_EXPORT __attribute__ ((dllexport))
+    #define RMW_FASTRTPS_SHARED_CPP_IMPORT __attribute__ ((dllimport))
   #else
-    #define RMW_FASTDDS_SHARED_CPP_EXPORT __declspec(dllexport)
-    #define RMW_FASTDDS_SHARED_CPP_IMPORT __declspec(dllimport)
+    #define RMW_FASTRTPS_SHARED_CPP_EXPORT __declspec(dllexport)
+    #define RMW_FASTRTPS_SHARED_CPP_IMPORT __declspec(dllimport)
   #endif
-  #ifdef RMW_FASTDDS_SHARED_CPP_BUILDING_LIBRARY
-    #define RMW_FASTDDS_SHARED_CPP_PUBLIC RMW_FASTDDS_SHARED_CPP_EXPORT
+  #ifdef RMW_FASTRTPS_SHARED_CPP_BUILDING_LIBRARY
+    #define RMW_FASTRTPS_SHARED_CPP_PUBLIC RMW_FASTRTPS_SHARED_CPP_EXPORT
   #else
-    #define RMW_FASTDDS_SHARED_CPP_PUBLIC RMW_FASTDDS_SHARED_CPP_IMPORT
+    #define RMW_FASTRTPS_SHARED_CPP_PUBLIC RMW_FASTRTPS_SHARED_CPP_IMPORT
   #endif
-  #define RMW_FASTDDS_SHARED_CPP_PUBLIC_TYPE RMW_FASTDDS_SHARED_CPP_PUBLIC
-  #define RMW_FASTDDS_SHARED_CPP_LOCAL
+  #define RMW_FASTRTPS_SHARED_CPP_PUBLIC_TYPE RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  #define RMW_FASTRTPS_SHARED_CPP_LOCAL
 #else
-  #define RMW_FASTDDS_SHARED_CPP_EXPORT __attribute__ ((visibility("default")))
-  #define RMW_FASTDDS_SHARED_CPP_IMPORT
+  #define RMW_FASTRTPS_SHARED_CPP_EXPORT __attribute__ ((visibility("default")))
+  #define RMW_FASTRTPS_SHARED_CPP_IMPORT
   #if __GNUC__ >= 4
-    #define RMW_FASTDDS_SHARED_CPP_PUBLIC __attribute__ ((visibility("default")))
-    #define RMW_FASTDDS_SHARED_CPP_LOCAL  __attribute__ ((visibility("hidden")))
+    #define RMW_FASTRTPS_SHARED_CPP_PUBLIC __attribute__ ((visibility("default")))
+    #define RMW_FASTRTPS_SHARED_CPP_LOCAL  __attribute__ ((visibility("hidden")))
   #else
-    #define RMW_FASTDDS_SHARED_CPP_PUBLIC
-    #define RMW_FASTDDS_SHARED_CPP_LOCAL
+    #define RMW_FASTRTPS_SHARED_CPP_PUBLIC
+    #define RMW_FASTRTPS_SHARED_CPP_LOCAL
   #endif
-  #define RMW_FASTDDS_SHARED_CPP_PUBLIC_TYPE
+  #define RMW_FASTRTPS_SHARED_CPP_PUBLIC_TYPE
 #endif
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__VISIBILITY_CONTROL_H_

--- a/rmw_fastrtps_shared_cpp/package.xml
+++ b/rmw_fastrtps_shared_cpp/package.xml
@@ -16,14 +16,12 @@
   <author>Ricardo González</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <build_depend>rosidl_dynamic_typesupport</build_depend>
   <build_depend>fastcdr</build_depend>
   <build_depend>fastdds</build_depend>
-  <build_depend>fastrtps_cmake_module</build_depend>
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -36,7 +34,6 @@
   <build_export_depend>rosidl_dynamic_typesupport</build_export_depend>
   <build_export_depend>fastcdr</build_export_depend>
   <build_export_depend>fastdds</build_export_depend>
-  <build_export_depend>fastrtps_cmake_module</build_export_depend>
   <build_export_depend>rcpputils</build_export_depend>
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw</build_export_depend>

--- a/rmw_fastrtps_shared_cpp/rmw_fastrtps_shared_cpp-extras.cmake
+++ b/rmw_fastrtps_shared_cpp/rmw_fastrtps_shared_cpp-extras.cmake
@@ -14,10 +14,8 @@
 
 # copied from rmw_fastrtps_shared_cpp/rmw_fastrtps_shared_cpp-extras.cmake
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr 2 REQUIRED CONFIG)
-find_package(fastdds 3.0 REQUIRED CONFIG)
-find_package(FastDDS 3.0 REQUIRED MODULE)
+find_package(fastcdr 2 REQUIRED)
+find_package(fastdds 3 REQUIRED)
 
 list(APPEND rmw_fastrtps_shared_cpp_INCLUDE_DIRS ${FastDDS_INCLUDE_DIR})
 # specific order: dependents before dependencies

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -177,7 +177,7 @@ __rmw_borrow_loaned_message(
   }
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
-  if (!info->data_writer_->loan_sample(*ros_message)) {
+  if (eprosima::fastdds::dds::RETCODE_OK != info->data_writer_->loan_sample(*ros_message)) {
     return RMW_RET_ERROR;
   }
 
@@ -202,7 +202,7 @@ __rmw_return_loaned_message_from_publisher(
   RMW_CHECK_ARGUMENT_FOR_NULL(loaned_message, RMW_RET_INVALID_ARGUMENT);
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
-  if (!info->data_writer_->discard_loan(loaned_message)) {
+  if (eprosima::fastdds::dds::RETCODE_OK != info->data_writer_->discard_loan(loaned_message)) {
     return RMW_RET_ERROR;
   }
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -643,7 +643,8 @@ __rmw_return_loaned_message_from_subscription(
   std::unique_ptr<rmw_fastrtps_shared_cpp::LoanManager::Item> item;
   item = info->loan_manager_->erase_item(loaned_message);
   if (item != nullptr) {
-    if (!info->data_reader_->return_loan(item->data_seq, item->info_seq)) {
+    auto ret_code = info->data_reader_->return_loan(item->data_seq, item->info_seq);
+    if (eprosima::fastdds::dds::RETCODE_OK != ret_code) {
       RMW_SET_ERROR_MSG("Error returning loan");
       return RMW_RET_ERROR;
     }


### PR DESCRIPTION
This is a follow-up from #32 that brings the following changes:

- Allows building without a `FindFastDDS.cmake` module
- Fixes return checks on writer loans APIs
- Revert changes on DLL export macros to fix Windows